### PR TITLE
Patch InputJSONEncoder to handle dates/times

### DIFF
--- a/wagtail_react_streamfield/widgets.py
+++ b/wagtail_react_streamfield/widgets.py
@@ -1,9 +1,12 @@
+import datetime
 import json
 from json import JSONEncoder
 from uuid import uuid4
 
+from django.conf import settings
 from django.forms import Media
 from django.utils.safestring import mark_safe
+from wagtail.admin.widgets import DEFAULT_DATE_FORMAT, DEFAULT_DATETIME_FORMAT
 from wagtail.core.blocks import (
     BlockWidget, StructBlock, ListBlock, FieldBlock, RichTextBlock,
     StreamBlock, ChooserBlock,
@@ -19,9 +22,18 @@ class ConfigJSONEncoder(JSONEncoder):
 class InputJSONEncoder(JSONEncoder):
     def default(self, o):
         if isinstance(o, BlockData):
+            value = o['value']
+            if isinstance(value, datetime.datetime):
+                fmt = getattr(settings, 'WAGTAIL_DATETIME_FORMAT', DEFAULT_DATETIME_FORMAT)
+                value = value.strftime(fmt)
+            elif isinstance(value, datetime.date):
+                fmt = getattr(settings, 'WAGTAIL_DATE_FORMAT', DEFAULT_DATETIME_FORMAT)
+                value = value.strftime(fmt)
+            elif isinstance(value, datetime.time):
+                value = value.strftime('%H:%M')
             return {'id': o['id'],
                     'type': o['type'],
-                    'value': o['value']}
+                    'value': value}
         return super().default(o)
 
 


### PR DESCRIPTION
Hi @BertrandBordage 

I have been testing this package on an existing Wagtail project, and we're really looking forward to using this. Great stuff so far.

I've run into an issue with DateBlocks, which I'm going to detail in a new issue. This is a mere proof-of-concept PR to handle DateBlocks, which are currently throwing a 500 for me when passed to `render_with_errors`.  This patch is more or less a direct adaptation of [this commit to wagtail-condensedinlinepanel](https://github.com/wagtail/wagtail-condensedinlinepanel/pull/36/commits/df28954311504cbedf5eb710e87ff611bb1f25a7).