### PR TITLE
update requirement to account for image chooser dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ and report any bug you find.
 Requirements
 ------------
 
-Wagtail 2.0 or above.
+Wagtail 2.2 or above.
 
 
 Getting started

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-wagtail>=2.0
+wagtail>=2.2


### PR DESCRIPTION
This appears to be necessary, I ran into issues when testing react streamfields for an existing wagtail project. Trying to open an image chooser fails with a JS error [here](https://github.com/noripyt/wagtail-react-streamfield/blob/master/wagtail_react_streamfield/static/wagtailimages/js/image-chooser.js#L24)

this appears to happen because wagtail-react-streamfield depends on [this](https://github.com/wagtail/wagtail/blob/master/wagtail/images/widgets.py#L36), which was introduced in wagtail 2.2
